### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ composer require srwiez/queue-size-health-check
 ## Usage
 
 ```php
-use QueueSizeHealthCheck\QueueSizeCheck;
+use QueueSizeCheck\QueueSizeCheck;
 
 QueueSizeCheck::new()
     ->queue('static_cache', 3)


### PR DESCRIPTION
Updated the typo error in the import namespace from `QueueSizeHealthCheck\QueueSizeCheck` to `QueueSizeCheck\QueueSizeCheck`